### PR TITLE
04-databases-assignment

### DIFF
--- a/lib/bloc_record/utility.rb
+++ b/lib/bloc_record/utility.rb
@@ -9,6 +9,7 @@ module BlocRecord
 		end
 
 		def convert_keys(options)
+			puts options
 			options.keys.each { |k| 
 				options[k.to_s] = options.delete(k) if k.kind_of?(Symbol)
 			}
@@ -49,8 +50,12 @@ module BlocRecord
 			case value
 			when String 
 				"'#{value}'"
-			when Numeric 
+			when Numeric, Symbol 
 				value.to_s
+			when Hash 
+				order = value.keys[0].to_s
+				order += " "
+				order += value[value.keys[0]].to_s
 			else
 				"null"
 			end


### PR DESCRIPTION
So, I decided to set a variable @joins to contain the join statement.  A subsequent call to the .where() method would add the @joins in its SQL statement.  Since the .join() would store this variable indefinitely, you would need to call the .join() method with zero arguments to clear the string.